### PR TITLE
Downgrading urllib3 to avoid vulnerabilities

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1627,17 +1627,18 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.1.0"
+version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.1.0-py3-none-any.whl", hash = "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3"},
-    {file = "urllib3-2.1.0.tar.gz", hash = "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"},
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
@@ -1925,4 +1926,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "8f41e6ea80ea9ac718b225c7ee05644d5f38d70d21b2a3dff6cd445002a7ee96"
+content-hash = "280f23108a3efbef29f6cb561490e9f8a09d6c71b20d8ad3fe013e7fb28a4ba8"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -26,6 +26,7 @@ infisical = "^1.5.0"
 pandas = "^2.1.4"
 validate-docbr = "^1.10.0"
 pyjwt = "^2.8.0"
+urllib3 = "2.0.7"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Vulnerabilidades resolvidas
- https://github.com/prefeitura-rio/prontuario-integrado/security/dependabot/6
- https://github.com/prefeitura-rio/prontuario-integrado/security/dependabot/5